### PR TITLE
implement base cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  myself.
 
  ## TODO:
- - [ ] create basic cli that will accept a filepath
+ - [x] create basic cli that will accept filepath(s)
  - [ ] given a file path, list back the markdown files that we will present
  - [ ] given a list of markdown files, create web server and serve those files
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/devsquared/slaMDown/processor"
 	"github.com/spf13/cobra"
 )
 
@@ -18,18 +19,38 @@ func main() {
 		Use:     "slamdown [flags] [directory]",
 		Short:   "slamdown [directory]",
 		Long:    "slaMDown your markdown files from a directory to a parsed display locally",
-		Version: "1", // TODO: make a processor for this?
+		Version: processor.Version,
 		Run: func(cmd *cobra.Command, args []string) {
-			//TODO: here we will call any setup we want from the processor package
-
-			//TODO: and then one final processor.Process()
-			fmt.Println("processing the commands")
+			processor.DirFilePaths = args // pass directly
+			processor.Process()
 		},
 	}
 
-	//TODO: utilize this space to add any flags that we want. As of now, those are:
-	// - port
-	// - light (for lightmode)
+	flags := rootCommand.PersistentFlags()
+
+	flags.BoolVarP(
+		&processor.Debug,
+		"debug",
+		"d",
+		false,
+		"Use to switch to debug logging on.",
+	)
+
+	flags.BoolVarP(
+		&processor.LightMode,
+		"lightmode",
+		"l",
+		false,
+		"Use to switch to light mode for the locally served files.",
+	)
+
+	flags.StringVarP(
+		&processor.Port,
+		"port",
+		"p",
+		"8080",
+		"Define the port to be used when serving files locally.",
+	)
 
 	if err := rootCommand.Execute(); err != nil {
 		os.Exit(1)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,0 +1,62 @@
+package processor
+
+import (
+	"fmt"
+	"time"
+)
+
+// Version is the version of the application.
+var Version = "1.0.0"
+
+// DirFilePaths is set from args to the application; not flag. These are a slice of strings and will be validated.
+var DirFilePaths []string
+
+// Debug is a flag used to turn on verbose logging.
+var Debug = false
+
+// LightMode is a variable indicating if the user wants to use the application in light or dark mode.
+var LightMode = false
+
+// Port is the port used when serving locally to the web.
+var Port = "8080"
+
+func Process() {
+	processFlags() // start with this to properly debug out context of the application
+
+	if len(DirFilePaths) == 0 {
+		printError("no directories or files given")
+	}
+
+	if Debug {
+		printDebug(fmt.Sprintf("taking a look at the following paths: %v", DirFilePaths))
+	}
+}
+
+func processFlags() {
+	if Debug {
+		printDebug(fmt.Sprintf("Version: %s", Version))
+		printDebug(fmt.Sprintf("LightMode: %v", LightMode))
+		printDebug(fmt.Sprintf("Port: %s", Port))
+	}
+}
+
+//TODO: we could move all of this formatter logic over to a formatter package.
+
+func printDebug(m string) {
+	if Debug {
+		fmt.Printf("DEBUG-%s: %s\n", getFormattedTime(), m)
+	}
+}
+
+func printWarn(m string) {
+	fmt.Printf("WARN-%s: %s\n", getFormattedTime(), m)
+}
+
+func printError(m string) {
+	fmt.Printf("ERROR-%s: %s\n", getFormattedTime(), m)
+}
+
+// Get the time as standard UTC/Zulu format
+func getFormattedTime() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}


### PR DESCRIPTION
The base CLI implemented here allows for the passing in of filepaths as arguments as well as flags for debugging, lightmode, and port. These flags do not have implemented logic behind them but can now be accepted. 